### PR TITLE
Log extra information when PUT request fails

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lpdc-publish-service",
-  "version": "0.8.0-rc1",
+  "version": "0.8.0-rc2",
   "description": "",
   "main": "app.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "lpdc-publish-service",
   "version": "0.8.0-rc1",
   "description": "",
-  "main": "app.ts",
+  "main": "app.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lpdc-publish-service",
-  "version": "0.7.0",
+  "version": "0.8.0-rc1",
   "description": "",
   "main": "app.ts",
   "scripts": {

--- a/utils/putDataToIpdc.js
+++ b/utils/putDataToIpdc.js
@@ -28,9 +28,11 @@ export async function putDataToIpdc(subjectsAndData) {
   });
 
   if (!response.ok) {
-    throw new Error("something went wrong when submitting to ipdc: \n"+JSON.stringify(response));
+    throw new Error("Something went wrong when submitting to IPDC: \n" + "IPDC response: " + JSON.stringify(response) + "\n"
+                    + "Response status code: " + response.status + "\n"
+                    + "Data sent to IPDC: " + JSON.stringify(doc));
   }
-  else{
-    console.log("succesfully sent data to ipdc: \n"+JSON.stringify(doc))
+  else {
+    console.log("Successfully sent data to IPDC: \n" + JSON.stringify(doc));
   }
 }

--- a/utils/putDataToIpdc.js
+++ b/utils/putDataToIpdc.js
@@ -1,5 +1,6 @@
 import * as jsonld from 'jsonld';
 import N3 from 'n3';
+import fetch from 'node-fetch';
 import { IPDC_JSON_ENDPOINT, IPDC_X_API_KEY } from '../env-config';
 
 export async function putDataToIpdc(subjectsAndData) {


### PR DESCRIPTION
(Addresses DL-5096) Log extra information when PUT request fails to improve error logs.

To test:
* Log in as any Gemeente
* Go to the `Producten- en dienstencatalogus` module
* Create a completely new service
* Add any random title and description
* Add an empty `Meer info` section at the bottom of the `Inhoud` tab
* Publish the service -> Service should fail to publish
* The `docker-compose` logs of `lpdc-publish` should show the extra information