### PR TITLE
chore: update woodpecker configuration

### DIFF
--- a/.woodpecker/.latest.yml
+++ b/.woodpecker/.latest.yml
@@ -17,4 +17,4 @@ steps:
         from_secret: woodpecker_token
 when:
   - event: push
-    branch: [development]
+    branch: [master]


### PR DESCRIPTION
In order to bring LPDC more in line with other apps we switch to using the
master branch as primary branch. This PR updates the woodpecker CI to build from the master branch instead of development branch.